### PR TITLE
DM-49669: Update for v2 pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,18 @@ gcloud storage rsync --recursive --no-ignore-symlinks datastore_symlinks gs://bu
 
 Then open up an RSP notebook session in the target IDF environment, and upload the `dp1-dump.tar` file created at USDF.
 ```
+# Load the Butler Registry DB
+setup lsst_distrib
+tar -xf ~/dp1-dump.tar
+python import_preliminary_dp1.py --seed butler-configs/idfdev.yaml # or other seed depending on environment
+# Create a top-level collection chain pointing to the imported collection
+butler collection-chain import-test-repo LSSTComCam/DP1 LSSTComCam/runs/DRP/DP1/w_2025_11/DM-49472
+```
 
+At USDF:
+```
+# Generate an ObsCore table for qserv
+python import_preliminary_dp1.py
+butler collection-chain import-test-repo LSSTComCam/DP1 LSSTComCam/runs/DRP/DP1/w_2025_11/DM-49472
+butler obscore export --format csv -c ~/repos/dax_obscore/configs/dp1.yaml import-test-repo dp1.csv
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# dp1-data-wrangling
+
+Miscellaneous scripts that will be used to prepare Rubin Data Preview 1 data
+for transfer to the Rubin Science Platform on Google Cloud.
+
+The current status of the preliminary setup is [on
+Confluence](https://rubinobs.atlassian.net/wiki/spaces/DM/pages/492142836/Preliminary+DP1+Butler+at+IDF).
+
+## Sequence of steps to transfer data from USDF TO IDF
+
+At USDF:
+```
+# Export from Postgres to parquet files.
+python export_preliminary_dp1.py
+tar -cf dp1-dump.tar dp1-dump-test/
+
+# Generate a directory full of symlinks pointing
+# to the files that will be included in the
+# data preview.
+python generate_dp1_datastore_symlinks.py
+
+# Transfer artifacts to Google Cloud --
+# Switch to a dedicated data transfer node
+# with better network bandwidth.
+ssh s3dfdtn.slac.stanford.edu
+# Start a screen session to keep the transfer going
+# if the network drops.
+screen
+# Copy files to GCS
+gcloud auth login
+gcloud storage rsync --recursive --no-ignore-symlinks datastore_symlinks gs://butler-us-central1-dp1/
+```
+
+Then open up an RSP notebook session in the target IDF environment, and upload the `dp1-dump.tar` file created at USDF.
+```
+
+```

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,0 @@
-##################
-dp1-data-wrangling
-##################
-
-Miscellaneous scripts that will be used to prepare Rubin Data Preview 1 data
-for transfer to the Rubin Science Platform on Google Cloud.

--- a/butler-configs/idfdev.yaml
+++ b/butler-configs/idfdev.yaml
@@ -1,3 +1,3 @@
 registry:
   db: postgresql://butler@dp1.rsp-sql-dev.internal:5432/dp1
-  namespace: prelim1
+  namespace: prelim2

--- a/butler-configs/idfint.yaml
+++ b/butler-configs/idfint.yaml
@@ -1,3 +1,3 @@
 registry:
   db: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
-  namespace: prelim1
+  namespace: prelim2

--- a/python/lsst/dp1_data_wrangling/export_dp1.py
+++ b/python/lsst/dp1_data_wrangling/export_dp1.py
@@ -29,8 +29,10 @@ DATASET_TYPES = [
     "dia_object",
     "dia_source",
     # 'deepCoadd_*_consolidated_map*' found in _find_extra_dataset_types() below.
-    "ss_source",
-    "ss_object"
+    # "ss_source" and "ss_object" are not in the ComCam DRP output yet,
+    # but they will be in future DRP runs.
+    # "ss_source",
+    # "ss_object",
     # "Tier 1b" minor data products.  Additional dataset types from this list
     # are located in _find_extra_dataset_types(), below.
     "visit_summary",

--- a/python/lsst/dp1_data_wrangling/export_dp1.py
+++ b/python/lsst/dp1_data_wrangling/export_dp1.py
@@ -28,7 +28,8 @@ DATASET_TYPES = [
     "dia_object_forced_source",
     "dia_object",
     "dia_source",
-    # 'deepCoadd_*_consolidated_map*' found in _find_extra_dataset_types() below.
+    # 'deepCoadd_*_consolidated_map*' found in _find_extra_dataset_types()
+    # below.
     # "ss_source" and "ss_object" are not in the ComCam DRP output yet,
     # but they will be in future DRP runs.
     # "ss_source",

--- a/python/lsst/dp1_data_wrangling/export_dp1.py
+++ b/python/lsst/dp1_data_wrangling/export_dp1.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 from collections.abc import Iterator
 
 from lsst.daf.butler import Butler, DataCoordinate
@@ -7,27 +8,33 @@ from pyarrow.parquet import ParquetFile
 
 from .exporter import MAX_ROWS_PER_WRITE, Exporter
 
-COLLECTION = "LSSTComCam/runs/DRP/DP1/w_2025_06/DM-48810"
+COLLECTION = "LSSTComCam/runs/DRP/DP1/w_2025_11/DM-49472"
 # Based on a preliminary list provided by Jim Bosch at
 # https://rubinobs.atlassian.net/wiki/spaces/~jbosch/pages/423559233/DP1+Dataset+Retention+Removal+Planning
 DATASET_TYPES = [
-    # "Tier 1" major data products
+    # "Tier 1" major data products.
     "raw",
-    "ccdVisitTable",
-    "visitTable",
-    "pvi",
-    "pvi_background",
-    "sourceTable_visit",
-    "deepCoadd_calexp",
-    "deepCoadd_calexp_background",
-    "goodSeeingCoadd",
-    "objectTable_tract",
-    "forcedSourceTable",
-    "diaObjectTable_tract",
-    "diaSourceTable_tract",
+    "visit_detector_table",
+    "visit_table",
+    "visit_image",
+    "visit_image_background",
+    "source",
+    "deep_coadd",
+    "deep_coadd_background",
+    "template_coadd",
+    "object",
+    "object_scarlet_models",
+    "object_forced_source",
+    "dia_object_forced_source",
+    "dia_object",
+    "dia_source",
+    # 'deepCoadd_*_consolidated_map*' found in _find_extra_dataset_types() below.
+    "ss_source",
+    "ss_object"
     # "Tier 1b" minor data products.  Additional dataset types from this list
     # are located in _find_extra_dataset_types(), below.
-    "finalVisitSummary",
+    "visit_summary",
+    "deep_coadd_n_image",
     # "Tier 1c" calibration products and ancillary inputs
     "bfk",
     "camera",
@@ -38,7 +45,7 @@ DATASET_TYPES = [
     "ptc",
     # TODO: We might want to subset the_monster to only include portions that
     # overlap the DP1 dataset.
-    "the_monster_20240904",
+    "the_monster_20250219",
     "fgcmLookUpTable",
 ]
 
@@ -63,7 +70,12 @@ def _find_extra_dataset_types(butler: Butler) -> set[str]:
     # provenance.
     types = set()
     for dt in info.dataset_types:
-        if dt.endswith("_metadata") or dt.endswith("_log") or dt.endswith("_config"):
+        if (
+            dt.endswith("_metadata")
+            or dt.endswith("_log")
+            or dt.endswith("_config")
+            or fnmatch.fnmatchcase(dt, "deepCoadd_*_consolidated_map*")
+        ):
             types.add(dt)
     return types
 


### PR DESCRIPTION
Updated DP1 export script to reference the new "v2" dataset type names and add additional dataset types requested by the team.  Added some documentation about the process for transferring a release to IDF.