### PR TITLE
DM-51058: Add more dataset types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ssh s3dfdtn.slac.stanford.edu
 screen
 # Copy files to GCS
 gcloud auth login
-gcloud storage rsync --recursive --no-ignore-symlinks datastore_symlinks gs://butler-us-central1-dp1/
+gcloud storage rsync --recursive --no-ignore-symlinks datastore_symlinks gs://butler-us-central1-dp1/DM-51058
 ```
 
 Then open up an RSP notebook session in the target IDF environment, and upload the `dp1-dump.tar` file created at USDF.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ tar -xf ~/dp1-dump.tar
 python import_preliminary_dp1.py --seed butler-configs/idfdev.yaml # or other seed depending on environment
 # Generate an ObsCore table for qserv
 butler obscore export --format csv -c ~/repos/dax_obscore/configs/dp1.yaml import-test-repo dp1.csv
+
+# On production, you need to grant the Butler server's database user access to the schema created by
+# the importer.
+pgcli -h 10.163.1.2 -U your_postgres_user_name dp1
+GRANT USAGE ON SCHEMA dm_51058 TO butler
+GRANT SELECT ON ALL TABLES IN SCHEMA dm_51058 TO butler
+ALTER DEFAULT PRIVILEGES IN SCHEMA dm_51058 GRANT SELECT ON TABLES TO butler
 ```
 
 ### Adding missing dataset types after-the-fact

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Then open up an RSP notebook session in the target IDF environment, and upload t
 setup lsst_distrib
 tar -xf ~/dp1-dump.tar
 python import_preliminary_dp1.py --seed butler-configs/idfdev.yaml # or other seed depending on environment
-# Create a top-level collection chain pointing to the imported collection
-butler collection-chain import-test-repo LSSTComCam/DP1 LSSTComCam/runs/DRP/DP1/v29_0_0/DM-50260
 # Generate an ObsCore table for qserv
 butler obscore export --format csv -c ~/repos/dax_obscore/configs/dp1.yaml import-test-repo dp1.csv
 ```

--- a/butler-configs/idfdev.yaml
+++ b/butler-configs/idfdev.yaml
@@ -1,3 +1,3 @@
 registry:
   db: postgresql://butler@dp1.rsp-sql-dev.internal:5432/dp1
-  namespace: dm_50578
+  namespace: dm_51058

--- a/butler-configs/idfint.yaml
+++ b/butler-configs/idfint.yaml
@@ -1,3 +1,3 @@
 registry:
   db: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
-  namespace: dm_50578
+  namespace: dm_51058

--- a/butler-configs/idfprod.yaml
+++ b/butler-configs/idfprod.yaml
@@ -1,4 +1,4 @@
 registry:
   # AlloyDB master "butler-data-preview-stable-primary".
   db: postgresql://10.163.1.2:5432/dp1
-  namespace: dm_50578
+  namespace: dm_51058

--- a/butler-configs/idfprod.yaml
+++ b/butler-configs/idfprod.yaml
@@ -1,0 +1,4 @@
+registry:
+  # AlloyDB master "butler-data-preview-stable-primary".
+  db: postgresql://10.163.1.2:5432/dp1
+  namespace: dm_50578

--- a/python/lsst/dp1_data_wrangling/export_dp1.py
+++ b/python/lsst/dp1_data_wrangling/export_dp1.py
@@ -28,6 +28,7 @@ DATASET_TYPES = [
     "dia_object_forced_source",
     "dia_object",
     "dia_source",
+    "difference_image",
     # 'deepCoadd_*_consolidated_map*' found in _find_extra_dataset_types()
     # below.
     "ss_source",
@@ -48,6 +49,9 @@ DATASET_TYPES = [
     "the_monster_20250219",
     "fgcmLookUpTable",
     "skyMap",
+    "crosstalk",
+    "cti",
+    "illuminationCorrection",
 ]
 
 DEFAULT_EXPORT_DIRECTORY = "dp1-dump"

--- a/python/lsst/dp1_data_wrangling/export_dp1.py
+++ b/python/lsst/dp1_data_wrangling/export_dp1.py
@@ -66,7 +66,7 @@ def main(dataset_type: list[str], repo: str, collection: str, output_directory: 
     butler = Butler(repo)
 
     with butler.registry.caching_context():
-        dumper = Exporter(output_directory, butler)
+        dumper = Exporter(output_directory, butler, root_collection=collection)
 
         if dataset_type:
             exported_types = set(dataset_type)

--- a/python/lsst/dp1_data_wrangling/exporter.py
+++ b/python/lsst/dp1_data_wrangling/exporter.py
@@ -26,11 +26,12 @@ MAX_ROWS_PER_WRITE = 50000
 class Exporter:
     """Export DatasetRefs with associated dimension records to parquet files"""
 
-    def __init__(self, output_path: str, butler: Butler) -> None:
+    def __init__(self, output_path: str, butler: Butler, root_collection: str) -> None:
         self._dimensions: dict[str, DimensionRecordParquetWriter] = {}
         self._butler = butler
         self._paths = ExportPaths(output_path)
         self._paths.create_directories()
+        self._root_collection = root_collection
 
         self._dataset_types_written: set[str] = set()
         self._collections_seen: set[str] = set()
@@ -128,7 +129,9 @@ class Exporter:
         export_dataset_types(self._paths.dataset_type_path(), dataset_types)
 
         index = ExportIndex(
-            dimensions=list(self._dimensions.keys()), dataset_types=list(self._dataset_types_written)
+            dimensions=list(self._dimensions.keys()),
+            dataset_types=list(self._dataset_types_written),
+            root_collection=self._root_collection,
         )
         write_model_to_file(index, self._paths.index_path())
 

--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import re
 
 import click
-from lsst.daf.butler import Butler, Config
+from lsst.daf.butler import Butler, CollectionType, Config
 
 from .datastore_mapping import DatastoreMappingInput
 from .export_dp1 import DEFAULT_EXPORT_DIRECTORY
 from .importer import Importer
 
 OUTPUT_REPO = "import-test-repo"
+TOP_LEVEL_COLLECTION = "LSSTComCam/DP1"
 
 
 @click.command()
@@ -26,7 +27,9 @@ def main(seed: str | None, use_existing_repo: bool) -> None:
         Butler.makeRepo(OUTPUT_REPO, config=config)
     butler = Butler(OUTPUT_REPO, writeable=True)
     importer = Importer(DEFAULT_EXPORT_DIRECTORY, butler)
-    importer.import_all(datastore_mapping=_datastore_mapping_function)
+    index = importer.import_all(datastore_mapping=_datastore_mapping_function)
+    butler.collections.register(TOP_LEVEL_COLLECTION, CollectionType.CHAINED)
+    butler.collection_chains.redefine_chain(TOP_LEVEL_COLLECTION, index.root_collection)
 
 
 def make_datastore_path_relative(path: str) -> str:

--- a/python/lsst/dp1_data_wrangling/importer.py
+++ b/python/lsst/dp1_data_wrangling/importer.py
@@ -28,7 +28,7 @@ class Importer:
         self._paths = ExportPaths(input_path)
         self._butler = butler
 
-    def import_all(self, datastore_mapping: DatastoreMappingFunction) -> None:
+    def import_all(self, datastore_mapping: DatastoreMappingFunction) -> ExportIndex:
         index = read_model_from_file(ExportIndex, self._paths.index_path())
 
         # Dataset types have to be registered outside the transaction,
@@ -43,6 +43,8 @@ class Importer:
             self._import_datasets(dataset_types)
             self._import_associations(dataset_types)
             self._import_datastore(datastore_mapping)
+
+        return index
 
     def _import_dimension_records(self, dimensions: list[str]) -> None:
         universe = self._butler.dimensions

--- a/python/lsst/dp1_data_wrangling/index.py
+++ b/python/lsst/dp1_data_wrangling/index.py
@@ -6,3 +6,4 @@ import pydantic
 class ExportIndex(pydantic.BaseModel):
     dimensions: list[str]
     dataset_types: list[str]
+    root_collection: str


### PR DESCRIPTION
Prepare the next DP1 release:
* Added `difference_image`, `cti`, `crosstalk` and `illuminationCorrection` dataset types. 
* Automatically create the top-level chain, instead of this being a manual step
* Update documentation with instructions for deploying to the production instance.