### PR TITLE
DM-50677: Update data-int Butler seed to point to AlloyDB

### DIFF
--- a/butler-configs/idfint.yaml
+++ b/butler-configs/idfint.yaml
@@ -1,3 +1,4 @@
 registry:
-  db: postgresql://butler@dp1.rsp-sql-int.internal:5432/dp1
+  # AlloyDB master "butler-data-preview-int-primary".
+  db: postgresql://10.255.1.2:5432/dp1
   namespace: dm_51372


### PR DESCRIPTION
We are now finalizing the AlloyDB deployment, so DP1 will need to be uploaded to AlloyDB on data-int.