### PR TITLE
DM-51757: Make registry import script easier to run

### DIFF
--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -17,12 +17,25 @@ OUTPUT_REPO = "import-test-repo"
 @click.option(
     "--use-existing-repo", is_flag=True, help="Use existing Butler repository instead of creating a new one"
 )
-def main(seed: str | None, use_existing_repo: bool) -> None:
+@click.option("--db-schema", help="Schema name to use when creating the registry database")
+@click.option("--db-connection-string", help="Schema name to use when creating the registry database")
+def main(
+    seed: str | None,
+    use_existing_repo: bool,
+    db_schema: str | None = None,
+    db_connection_string: str | None = None,
+) -> None:
     if not use_existing_repo:
         if seed:
             config = Config(seed)
         else:
-            config = None
+            config = Config()
+        if db_connection_string is not None:
+            assert db_schema is not None, "--db-schema is required with --db-connection-string"
+            config["registry", "db"] = db_connection_string
+        if db_schema is not None:
+            assert db_connection_string is not None, "--db-connection-string is required with --db-schema"
+            config["registry", "namespace"] = db_schema
         Butler.makeRepo(OUTPUT_REPO, config=config)
     butler = Butler(OUTPUT_REPO, writeable=True)
     importer = Importer(DEFAULT_EXPORT_DIRECTORY, butler)

--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -44,11 +44,15 @@ def main(
                 # for the repository directory so this script can be run
                 # more than once.
                 output_repo = exit_stack.enter_context(tempfile.TemporaryDirectory())
+            print("Initializing repository...")
             Butler.makeRepo(output_repo, config=config)
 
+        print("Connecting to database...")
         butler = Butler(output_repo, writeable=True)
+        print("Importing DP1 registry...")
         importer = Importer(DEFAULT_EXPORT_DIRECTORY, butler)
         importer.import_all(datastore_mapping=_datastore_mapping_function)
+        print("Import complete")
 
 
 def make_datastore_path_relative(path: str) -> str:


### PR DESCRIPTION
Add some options to the registry import script to make it easier to run for setting up mirrors of DP1 at DESC and USDF.