### PR TITLE
Allow parquet input directory to be set in generate_dp1_datastore_symlinks.py

### DIFF
--- a/python/lsst/dp1_data_wrangling/generate_dp1_file_tree.py
+++ b/python/lsst/dp1_data_wrangling/generate_dp1_file_tree.py
@@ -16,12 +16,13 @@ from .paths import ExportPaths
 @click.command
 @click.option("--input-root", default="/sdf/group/rubin/repo/dp1/")
 @click.option("--output-root", default="datastore_symlinks")
-def main(input_root: str, output_root: str) -> None:
+@click.option("--export-dir", default=DEFAULT_EXPORT_DIRECTORY)
+def main(input_root: str, output_root: str, export_dir: str) -> None:
     output_dir = Path(output_root)
     output_dir.mkdir()
 
     count = 0
-    datastore_records_file = ExportPaths(DEFAULT_EXPORT_DIRECTORY).datastore_parquet_path()
+    datastore_records_file = ExportPaths(export_dir).datastore_parquet_path()
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         futures = []
         for path in _generate_file_list(input_root, datastore_records_file):

--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -20,12 +20,14 @@ from .importer import Importer
 @click.option("--db-schema", help="Schema name to use when creating the registry database")
 @click.option("--db-connection-string", help="Schema name to use when creating the registry database")
 @click.option("--no-datastore-remap", is_flag=True, help="Disable remapping of paths inside the datastore")
+@click.option("--input-dir", default=DEFAULT_EXPORT_DIRECTORY)
 def main(
     seed: str | None,
     use_existing_repo: bool,
     no_datastore_remap: bool,
     db_schema: str | None,
     db_connection_string: str | None,
+    input_dir: str,
 ) -> None:
     exit_stack = ExitStack()
     with exit_stack:
@@ -52,7 +54,7 @@ def main(
         print("Connecting to database...")
         butler = Butler(output_repo, writeable=True)
         print("Importing DP1 registry...")
-        importer = Importer(DEFAULT_EXPORT_DIRECTORY, butler)
+        importer = Importer(input_dir, butler)
         if no_datastore_remap:
             datastore_mapping = _null_datastore_mapping_function
         else:


### PR DESCRIPTION
Add a `--export-dir` flag that can be used to specify the source directory for the export dump that will be loaded in `generate_dp1_datastore_symlinks.py`, and `--input-dir` in `import_preliminary_dp1.py`.