### PR TITLE
DM-52432: Support IDAC import of DP1

### DIFF
--- a/python/lsst/dp1_data_wrangling/generate_dp1_file_tree.py
+++ b/python/lsst/dp1_data_wrangling/generate_dp1_file_tree.py
@@ -9,7 +9,7 @@ import click
 
 from .datastore_parquet import read_datastore_records_from_file
 from .export_dp1 import DEFAULT_EXPORT_DIRECTORY
-from .import_dp1 import make_datastore_path_relative
+from .import_dp1 import map_datastore_path_for_rsp
 from .paths import ExportPaths
 
 
@@ -51,7 +51,7 @@ def _generate_file_list(datastore_root_path: str, datastore_records_file_path: s
         for row in batch:
             original_path = row.file_info.path
             absolute_path = _make_path_absolute(datastore_root_path, original_path)
-            target_path = _strip_fragment(make_datastore_path_relative(original_path))
+            target_path = _strip_fragment(map_datastore_path_for_rsp(original_path))
             yield MappedPath(absolute_source=absolute_path, relative_target=target_path)
 
 

--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -26,6 +26,9 @@ from .importer import Importer
     default="rsp",
 )
 @click.option("--input-dir", default=DEFAULT_EXPORT_DIRECTORY)
+@click.option(
+    "--dataset-type", "-t", multiple=True, help="Subset the imported data to only the given dataset type"
+)
 def main(
     seed: str | None,
     use_existing_repo: bool,
@@ -34,6 +37,7 @@ def main(
     db_connection_string: str | None,
     input_dir: str,
     file_paths: str,
+    dataset_type: list[str] | None,
 ) -> None:
     exit_stack = ExitStack()
     with exit_stack:
@@ -60,7 +64,9 @@ def main(
         print("Connecting to database...")
         butler = Butler(output_repo, writeable=True)
         print("Importing DP1 registry...")
-        importer = Importer(input_dir, butler)
+        if not dataset_type:
+            dataset_type = None
+        importer = Importer(input_dir, butler, dataset_type)
         if no_datastore_remap:
             datastore_mapping = _null_datastore_mapping_function
         elif file_paths == "rsp":

--- a/python/lsst/dp1_data_wrangling/import_dp1.py
+++ b/python/lsst/dp1_data_wrangling/import_dp1.py
@@ -20,6 +20,11 @@ from .importer import Importer
 @click.option("--db-schema", help="Schema name to use when creating the registry database")
 @click.option("--db-connection-string", help="Schema name to use when creating the registry database")
 @click.option("--no-datastore-remap", is_flag=True, help="Disable remapping of paths inside the datastore")
+@click.option(
+    "--file-paths",
+    help="Selects the directory layout to use for the imported files.  Options are 'rsp' or 'rucio'",
+    default="rsp",
+)
 @click.option("--input-dir", default=DEFAULT_EXPORT_DIRECTORY)
 def main(
     seed: str | None,
@@ -28,6 +33,7 @@ def main(
     db_schema: str | None,
     db_connection_string: str | None,
     input_dir: str,
+    file_paths: str,
 ) -> None:
     exit_stack = ExitStack()
     with exit_stack:
@@ -57,15 +63,25 @@ def main(
         importer = Importer(input_dir, butler)
         if no_datastore_remap:
             datastore_mapping = _null_datastore_mapping_function
+        elif file_paths == "rsp":
+            datastore_mapping = _rsp_datastore_mapping_function
+        elif file_paths == "rucio":
+            datastore_mapping = _rucio_datastore_mapping_function
         else:
-            datastore_mapping = _datastore_mapping_function
+            raise ValueError(f"Unknown value for --file-paths: {file_paths}")
 
         importer.import_all(datastore_mapping=datastore_mapping)
         print("Import complete")
 
 
-def make_datastore_path_relative(path: str) -> str:
-    path = path.replace("file:///sdf/data/rubin/", "external/rubin/")
+_EXTERNAL_FILES_PREFIX = "file:///sdf/data/rubin/"
+
+
+def map_datastore_path_for_rsp(path: str) -> str:
+    """Remap a path to match the directory layout in the Google RSP deployment
+    of DP1.
+    """
+    path = path.replace(_EXTERNAL_FILES_PREFIX, "external/rubin/")
 
     if re.match(r"^[\w+]+://", path):
         raise ValueError(f"Unhandled absolute path to datastore file: {path}")
@@ -73,11 +89,26 @@ def make_datastore_path_relative(path: str) -> str:
     return path
 
 
-def _datastore_mapping_function(input: DatastoreMappingInput) -> DatastoreMappingInput:
-    path = make_datastore_path_relative(input.path)
+def _rsp_datastore_mapping_function(input: DatastoreMappingInput) -> DatastoreMappingInput:
+    path = map_datastore_path_for_rsp(input.path)
     # /repo/main and target repo both use the default
     # "FileDatastore@<butlerRoot>" datastore name, so we don't need to remap
     # the datastore name.
+    return input._replace(path=path)
+
+
+def _rucio_datastore_mapping_function(input: DatastoreMappingInput) -> DatastoreMappingInput:
+    path = input.path
+
+    raw_prefix = _EXTERNAL_FILES_PREFIX + "lsstdata/offline/instrument/"
+    refcat_prefix = _EXTERNAL_FILES_PREFIX + "shared/"
+    if path.startswith(raw_prefix):
+        path = path.replace(raw_prefix, "raw/")
+    elif path.startswith(refcat_prefix):
+        path = path.replace(refcat_prefix, "raw/")
+    else:
+        path = "dp1/" + path
+
     return input._replace(path=path)
 
 


### PR DESCRIPTION
Added two features that will be needed by IDACs to set up the Butler repository for DP1:
1. `--file-paths rucio` command line option to remap the imported file paths to match the files obtained via Rucio.
2. `--dataset-type` command line option to select a subset of dataset types for import